### PR TITLE
removed unused mysql dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,6 @@
         <commons-lang.version>2.6</commons-lang.version>
         <commons-lang3.version>3.4</commons-lang3.version>
         <postgresql.version>9.1-901.jdbc3</postgresql.version>
-        <mysql.version>5.1.21</mysql.version>
         <slf4j.version>1.6.6</slf4j.version>
         <log4j.version>1.2.16</log4j.version>
         <log4j-core.version>2.13.2</log4j-core.version>
@@ -361,11 +360,6 @@
                 <groupId>postgresql</groupId>
                 <artifactId>postgresql</artifactId>
                 <version>${postgresql.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>mysql</groupId>
-                <artifactId>mysql-connector-java</artifactId>
-                <version>${mysql.version}</version>
             </dependency>
             <dependency>
                 <groupId>ca.on.oicr.gsi</groupId>


### PR DESCRIPTION
This probably hasn't been used since Pinery-MISO was moved into the MISO project