### PR TITLE
Try to remove unnecessary dependencies

### DIFF
--- a/pinery-api/pom.xml
+++ b/pinery-api/pom.xml
@@ -13,19 +13,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/pinery-client/pom.xml
+++ b/pinery-client/pom.xml
@@ -25,19 +25,11 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jaxrs</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jackson2-provider</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -54,14 +46,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>commons-configuration</groupId>
-            <artifactId>commons-configuration</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/pinery-client/src/main/java/ca/on/oicr/pinery/client/PineryClient.java
+++ b/pinery-client/src/main/java/ca/on/oicr/pinery/client/PineryClient.java
@@ -2,7 +2,6 @@ package ca.on.oicr.pinery.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.google.common.annotations.VisibleForTesting;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.X509Certificate;
@@ -69,8 +68,7 @@ public class PineryClient implements AutoCloseable {
         ignoreHttpsWarnings ? PineryClient.getInsecureClient() : PineryClient.getSecureClient());
   }
 
-  @VisibleForTesting
-  protected PineryClient(String baseUrl, Client client) {
+  public PineryClient(String baseUrl, Client client) {
     this.pineryBaseUrl = baseUrl.endsWith("/") ? baseUrl : baseUrl + "/";
     this.client = client;
     // Register provider manually because it Was not registering automatically in dependent projects

--- a/pinery-lims/src/main/java/ca/on/oicr/pinery/lims/SimpleLaneProvenance.java
+++ b/pinery-lims/src/main/java/ca/on/oicr/pinery/lims/SimpleLaneProvenance.java
@@ -1,8 +1,8 @@
 package ca.on.oicr.pinery.lims;
 
 import ca.on.oicr.gsi.provenance.model.LaneProvenance;
-import com.google.common.base.Charsets;
 import com.google.common.hash.Hashing;
+import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;
 import java.util.SortedMap;
 import java.util.SortedSet;
@@ -62,7 +62,7 @@ public class SimpleLaneProvenance implements LaneProvenance {
     sb.append(getLaneNumber());
     sb.append(getLaneAttributes());
     String s = sb.toString();
-    return Hashing.sha256().hashString(s, Charsets.UTF_8).toString();
+    return Hashing.sha256().hashString(s, StandardCharsets.UTF_8).toString();
   }
 
   @Override

--- a/pinery-lims/src/main/java/ca/on/oicr/pinery/lims/SimpleSampleProvenance.java
+++ b/pinery-lims/src/main/java/ca/on/oicr/pinery/lims/SimpleSampleProvenance.java
@@ -1,8 +1,8 @@
 package ca.on.oicr.pinery.lims;
 
 import ca.on.oicr.gsi.provenance.model.SampleProvenance;
-import com.google.common.base.Charsets;
 import com.google.common.hash.Hashing;
+import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;
 import java.util.SortedMap;
 import java.util.SortedSet;
@@ -96,7 +96,7 @@ public class SimpleSampleProvenance implements SampleProvenance {
     sb.append(getLaneAttributes());
     sb.append(getIusTag());
     String s = sb.toString();
-    return Hashing.sha256().hashString(s, Charsets.UTF_8).toString();
+    return Hashing.sha256().hashString(s, StandardCharsets.UTF_8).toString();
   }
 
   @Override

--- a/pinery-ws-dto/pom.xml
+++ b/pinery-ws-dto/pom.xml
@@ -27,11 +27,7 @@
             <groupId>ca.on.oicr</groupId>
             <artifactId>pinery-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-        </dependency>
-        <dependency>
+       <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
         </dependency>

--- a/pinery-ws-dto/src/test/java/ca/on/oicr/DtosTest.java
+++ b/pinery-ws-dto/src/test/java/ca/on/oicr/DtosTest.java
@@ -22,9 +22,9 @@ import ca.on.oicr.ws.dto.OrderDtoSample;
 import ca.on.oicr.ws.dto.RunDto;
 import ca.on.oicr.ws.dto.RunDtoPosition;
 import ca.on.oicr.ws.dto.RunDtoSample;
-import com.google.common.collect.Sets;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.Set;
 import org.junit.Test;
 
@@ -84,7 +84,7 @@ public class DtosTest {
   @Test
   public void testOrder9() throws Exception {
     Order input = new DefaultOrder();
-    Set<OrderSample> samples = Sets.newHashSet();
+    Set<OrderSample> samples = new HashSet<>();
     OrderSample orderSample = new DefaultOrderSample();
     orderSample.setBarcode("ACTGGCCCATG");
     samples.add(orderSample);
@@ -96,7 +96,7 @@ public class DtosTest {
   @Test
   public void testOrder10() throws Exception {
     Order input = new DefaultOrder();
-    Set<OrderSample> samples = Sets.newHashSet();
+    Set<OrderSample> samples = new HashSet<>();
     OrderSample orderSample = new DefaultOrderSample();
     orderSample.setBarcode("ACTGGCCCATG");
     samples.add(orderSample);
@@ -118,7 +118,7 @@ public class DtosTest {
     boolean status;
     OrderSample orderSample = new DefaultOrderSample();
     Attribute attribute = new DefaultAttribute();
-    Set<Attribute> attributes = Sets.newHashSet();
+    Set<Attribute> attributes = new HashSet<>();
     attribute.setName("read length");
     attribute.setValue("2x101");
     attributes.add(attribute);
@@ -135,7 +135,7 @@ public class DtosTest {
     boolean status;
     OrderSample orderSample = new DefaultOrderSample();
     Attribute attribute = new DefaultAttribute();
-    Set<Attribute> attributes = Sets.newHashSet();
+    Set<Attribute> attributes = new HashSet<>();
     attribute.setValue("2x101");
     attributes.add(attribute);
     orderSample.setAttributes(attributes);
@@ -148,7 +148,7 @@ public class DtosTest {
 
   @Test
   public void testSetOrderSample_too_OrderSample() throws Exception {
-    Set<OrderSample> input = Sets.newHashSet();
+    Set<OrderSample> input = new HashSet<>();
     OrderSample orderSample = new DefaultOrderSample();
     orderSample.setBarcode("ABC");
     input.add(orderSample);
@@ -221,7 +221,7 @@ public class DtosTest {
   @Test
   public void testRun7() throws Exception {
     Run input = new DefaultRun();
-    Set<RunPosition> sample = Sets.newHashSet();
+    Set<RunPosition> sample = new HashSet<>();
     RunPosition runPosition = new DefaultRunPosition();
     runPosition.setPosition(23);
     sample.add(runPosition);
@@ -240,7 +240,7 @@ public class DtosTest {
 
   @Test
   public void testSetRunPosition_too_RunDtoPosition_9() throws Exception {
-    Set<RunPosition> input = Sets.newHashSet();
+    Set<RunPosition> input = new HashSet<>();
     RunPosition runPosition = new DefaultRunPosition();
     runPosition.setPosition(12);
     input.add(runPosition);
@@ -253,7 +253,7 @@ public class DtosTest {
     boolean status;
     RunPosition runPosition = new DefaultRunPosition();
     RunSample runSample = new DefaultRunSample();
-    Set<RunSample> runSamples = Sets.newHashSet();
+    Set<RunSample> runSamples = new HashSet<>();
     runSample.setBarcode("C2D8J");
     runSamples.add(runSample);
     runPosition.setRunSample(runSamples);
@@ -269,7 +269,7 @@ public class DtosTest {
     boolean status;
     RunPosition runPosition = new DefaultRunPosition();
     RunSample runSample = new DefaultRunSample();
-    Set<RunSample> runSamples = Sets.newHashSet();
+    Set<RunSample> runSamples = new HashSet<>();
     runSample.setUrl("https://pinery.res.oicr.on.ca:8443/pinery/sample/45");
     runSamples.add(runSample);
     runPosition.setRunSample(runSamples);
@@ -285,7 +285,7 @@ public class DtosTest {
     boolean status;
     RunPosition runPosition = new DefaultRunPosition();
     RunSample runSample = new DefaultRunSample();
-    Set<RunSample> runSamples = Sets.newHashSet();
+    Set<RunSample> runSamples = new HashSet<>();
     runSample.setId("12");
     runSamples.add(runSample);
     runPosition.setRunSample(runSamples);

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,6 @@
         <slf4j.version>1.6.6</slf4j.version>
         <log4j.version>1.2.16</log4j.version>
         <log4j-core.version>2.13.2</log4j-core.version>
-        <joda-time.version>2.1</joda-time.version>
         <mockito.version>1.10.19</mockito.version>
         <commons-configuration.version>1.10</commons-configuration.version>
         <httpclient.version>4.5.2</httpclient.version>
@@ -103,12 +102,7 @@
                 <artifactId>log4j-core</artifactId>
                 <version>${log4j-core.version}</version>
             </dependency>
-            <dependency>
-                <groupId>joda-time</groupId>
-                <artifactId>joda-time</artifactId>
-                <version>${joda-time.version}</version>
-            </dependency>
-            <dependency>
+           <dependency>
                 <groupId>ca.on.oicr</groupId>
                 <artifactId>pinery-api</artifactId>
                 <version>${project.version}</version>
@@ -228,11 +222,6 @@
             </dependency>
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
-                <artifactId>resteasy-jaxrs</artifactId>
-                <version>${resteasy.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-client</artifactId>
                 <version>${resteasy.version}</version>
             </dependency>
@@ -245,11 +234,6 @@
                 <groupId>com.opencsv</groupId>
                 <artifactId>opencsv</artifactId>
                 <version>${opencsv.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.httpcomponents</groupId>
-                <artifactId>httpclient</artifactId>
-                <version>${httpclient.version}</version>
             </dependency>
             <dependency>
                 <groupId>net.sourceforge.csvjdbc</groupId>
@@ -325,11 +309,6 @@
                 <artifactId>jetty-util</artifactId>
                 <version>${jetty.version}</version>
             </dependency>
-            <dependency>
-                <groupId>org.apache.maven.surefire</groupId>
-                <artifactId>surefire-junit47</artifactId>
-                <version>${surefire-junit47.version}</version>
-            </dependency>
 
             <dependency>
                 <groupId>commons-lang</groupId>
@@ -341,26 +320,13 @@
                 <artifactId>commons-lang3</artifactId>
                 <version>${commons-lang3.version}</version>
             </dependency>
-            <dependency>
-                <groupId>commons-configuration</groupId>
-                <artifactId>commons-configuration</artifactId>
-                <version>${commons-configuration.version}</version>
-            </dependency>
+
             <dependency>
                 <groupId>commons-beanutils</groupId>
                 <artifactId>commons-beanutils</artifactId>
                 <version>${commons-beanutils.version}</version>
             </dependency>
-            <dependency>
-                <groupId>commons-io</groupId>
-                <artifactId>commons-io</artifactId>
-                <version>${commons-io.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>postgresql</groupId>
-                <artifactId>postgresql</artifactId>
-                <version>${postgresql.version}</version>
-            </dependency>
+
             <dependency>
                 <groupId>ca.on.oicr.gsi</groupId>
                 <artifactId>provenance-api</artifactId>


### PR DESCRIPTION
There are some dependencies, particularly RESTEasy, which do not play well with
the module system. This tries to remove unused dependencies or things which are
now possible using the standard library.

It is still not possible to use `pinery-client` with the module system, but
`pinery-ws-dto` should be better.