### PR TITLE
[miso-lims#2626] align log4j and slf4j versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 target
 bin
+.idea/
 .project
 .classpath
 *.swp

--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,9 @@
         <commons-lang.version>2.6</commons-lang.version>
         <commons-lang3.version>3.4</commons-lang3.version>
         <postgresql.version>9.1-901.jdbc3</postgresql.version>
-        <slf4j.version>1.7.32</slf4j.version>
         <log4j.version>2.17.1</log4j.version>
+        <!-- Make sure to keep slf4j version in sync with version used by log4j-slf4j-impl -->
+        <slf4j.version>1.7.25</slf4j.version>
         <mockito.version>1.10.19</mockito.version>
         <commons-configuration.version>1.10</commons-configuration.version>
         <httpclient.version>4.5.2</httpclient.version>


### PR DESCRIPTION
The log4j-slf4j-impl pom actually has a comment to not use a later version of slf4j with it: https://search.maven.org/artifact/org.apache.logging.log4j/log4j-slf4j-impl/2.17.1/jar