### PR TITLE
[GLT-3643] mark provenance items as skipped based on run QC

### DIFF
--- a/pinery-lims/src/main/java/ca/on/oicr/pinery/lims/DefaultLaneProvenance.java
+++ b/pinery-lims/src/main/java/ca/on/oicr/pinery/lims/DefaultLaneProvenance.java
@@ -123,7 +123,15 @@ public class DefaultLaneProvenance implements LaneProvenance {
 
   @Override
   public Boolean getSkip() {
-    return lane.isAnalysisSkipped();
+    if ((sequencerRun.getStatus() == null
+            || "Not Ready".equals(sequencerRun.getStatus().getState()))
+        && lane.isAnalysisSkipped() == null) {
+      return null;
+    } else {
+      return (sequencerRun.getStatus() != null
+              && "Failed".equals(sequencerRun.getStatus().getState()))
+          || Boolean.TRUE.equals(lane.isAnalysisSkipped());
+    }
   }
 
   @Override

--- a/pinery-lims/src/main/java/ca/on/oicr/pinery/lims/DefaultSampleProvenance.java
+++ b/pinery-lims/src/main/java/ca/on/oicr/pinery/lims/DefaultSampleProvenance.java
@@ -314,12 +314,16 @@ public class DefaultSampleProvenance implements SampleProvenance {
 
   @Override
   public Boolean getSkip() {
-    if (lane.isAnalysisSkipped() == null
+    if ((sequencerRun.getStatus() == null
+            || "Not Ready".equals(sequencerRun.getStatus().getState()))
+        && lane.isAnalysisSkipped() == null
         && (runSample.getStatus() == null
             || "Not Ready".equals(runSample.getStatus().getState()))) {
       return null;
     } else {
-      return Boolean.TRUE.equals(lane.isAnalysisSkipped())
+      return (sequencerRun.getStatus() != null
+              && "Failed".equals(sequencerRun.getStatus().getState()))
+          || Boolean.TRUE.equals(lane.isAnalysisSkipped())
           || (runSample.getStatus() != null && "Failed".equals(runSample.getStatus().getState()));
     }
   }


### PR DESCRIPTION
Tested with current OICR production data. Only diff was `skip: false` -> `skip: true` - 41 instances in lane-provenance, and 1593 instances in sample-provenance