### PR TITLE
handle base URL with or without trailing slash in non-root context

### DIFF
--- a/pinery-ws/src/main/java/ca/on/oicr/pinery/ws/StatusController.java
+++ b/pinery-ws/src/main/java/ca/on/oicr/pinery/ws/StatusController.java
@@ -18,10 +18,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
-@RequestMapping("/")
 @Hidden
 public class StatusController {
   public static final ServerConfig SERVER_CONFIG = new ServerConfig() {


### PR DESCRIPTION
Jira ticket: n/a

- [ ] Commit message includes ticket number (n/a)
- [x] Relevant documentation updated (or n/a)
- [x] Relevant tests added/updated (or n/a)

The controller doesn't need a mapping because the one mapped method within has its own `GetMapping` annotation. The default mapping value is `""`, which handles the root path both with and without a slash.